### PR TITLE
fix: complete SPA redirect for GitHub Pages deep links

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -5,9 +5,15 @@
   <title>QuakeTracker</title>
   <script>
     // SPA redirect for GitHub Pages
-    sessionStorage.redirect = location.href;
+    // Stores the current path so index.html can restore it via history.replaceState
+    var pathSegmentsToKeep = 1; // keep '/quake-tracker' prefix
+    var l = window.location;
+    sessionStorage.redirect = l.pathname + l.search + l.hash;
+    l.replace(
+      l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+      l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/'
+    );
   </script>
-  <meta http-equiv="refresh" content="0;URL='/quake-tracker/'">
 </head>
 <body></body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -13,6 +13,16 @@
   <link rel="apple-touch-icon" href="icons/icon-192.svg">
 </head>
 <body>
+  <script>
+    // SPA redirect for GitHub Pages — restore path saved by 404.html
+    (function() {
+      var redirect = sessionStorage.redirect;
+      delete sessionStorage.redirect;
+      if (redirect && redirect !== location.pathname) {
+        history.replaceState(null, '', redirect);
+      }
+    })();
+  </script>
   <a class="skip-link" href="#main-content">Skip to main content</a>
   <app-root></app-root>
 </body>


### PR DESCRIPTION
## Summary
- Fixes the 404 error when navigating directly to detail links like `/quake-tracker/quake/us7000s39n`
- The existing `404.html` saved the path to `sessionStorage` but `index.html` had no corresponding script to restore it via `history.replaceState`
- Now the full SPA redirect flow works: 404.html saves path → redirects to root → index.html restores original path → Angular router picks it up

## Test plan
- [ ] Navigate directly to `https://corvid-agent.github.io/quake-tracker/quake/us7000s39n` — should load the detail page instead of 404
- [ ] Navigate to root `https://corvid-agent.github.io/quake-tracker/` — should still work as before
- [ ] Unit tests pass (`ng test --watch=false`)

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)